### PR TITLE
Hook import dynamic callback

### DIFF
--- a/src/isolate/holder.h
+++ b/src/isolate/holder.h
@@ -37,7 +37,7 @@ class IsolateHolder {
 		void Release();
 		auto GetIsolate() -> std::shared_ptr<IsolateEnvironment>;
 		void ScheduleTask(std::unique_ptr<Runnable> task, bool run_inline, bool wake_isolate, bool handle_task = false);
-
+		std::shared_ptr<IsolateHolder> import_dynamic_callback_host_isolate;
 		v8::Persistent<v8::Function> import_dynamic_callback;
 
 	 private:

--- a/src/isolate/holder.h
+++ b/src/isolate/holder.h
@@ -38,7 +38,9 @@ class IsolateHolder {
 		auto GetIsolate() -> std::shared_ptr<IsolateEnvironment>;
 		void ScheduleTask(std::unique_ptr<Runnable> task, bool run_inline, bool wake_isolate, bool handle_task = false);
 
-	private:
+		v8::Persistent<v8::Function> import_dynamic_callback;
+
+	 private:
 		lockable_t<std::shared_ptr<IsolateEnvironment>> isolate;
 };
 

--- a/src/module/isolate_handle.cc
+++ b/src/module/isolate_handle.cc
@@ -64,7 +64,9 @@ auto IsolateHandle::Definition() -> Local<FunctionTemplate> {
 }
 
 auto IsolateHandle::SetImportModuleDynamicCallback(Local<Function> cb)-> Local<Value> {
+	isolate->import_dynamic_callback_host_isolate = IsolateEnvironment::GetCurrentHolder();
 	isolate->import_dynamic_callback.Reset( Isolate::GetCurrent(), cb );
+
 	return Undefined( Isolate::GetCurrent() );
 }
 

--- a/src/module/isolate_handle.cc
+++ b/src/module/isolate_handle.cc
@@ -57,9 +57,15 @@ auto IsolateHandle::Definition() -> Local<FunctionTemplate> {
 		"isDisposed", MemberAccessor<decltype(&IsolateHandle::IsDisposedGetter), &IsolateHandle::IsDisposedGetter>{},
 		"referenceCount", MemberAccessor<decltype(&IsolateHandle::GetReferenceCount), &IsolateHandle::GetReferenceCount>{},
 		"wallTime", MemberAccessor<decltype(&IsolateHandle::GetWallTime), &IsolateHandle::GetWallTime>{},
+		"setImportModuleDynamicCallback", MemberFunction<decltype(&IsolateHandle::SetImportModuleDynamicCallback ), &IsolateHandle::SetImportModuleDynamicCallback>{},
 		"startCpuProfiler", MemberFunction<decltype(&IsolateHandle::StartCpuProfiler), &IsolateHandle::StartCpuProfiler>{},
 		"stopCpuProfiler", MemberFunction<decltype(&IsolateHandle::StopCpuProfiler<1>), &IsolateHandle::StopCpuProfiler<1>>{}
 	));
+}
+
+auto IsolateHandle::SetImportModuleDynamicCallback(Local<Function> cb)-> Local<Value> {
+	isolate->import_dynamic_callback.Reset( Isolate::GetCurrent(), cb );
+	return Undefined( Isolate::GetCurrent() );
 }
 
 /**
@@ -113,6 +119,7 @@ auto IsolateHandle::New(MaybeLocal<Object> maybe_options) -> unique_ptr<ClassHan
 	auto holder = IsolateEnvironment::New(memory_limit, std::move(snapshot_blob), snapshot_blob_length);
 	auto env = holder->GetIsolate();
 	env->GetIsolate()->SetHostInitializeImportMetaObjectCallback(ModuleHandle::InitializeImportMeta);
+	env->GetIsolate()->SetHostImportModuleDynamicallyCallback(ModuleHandle::ImportModuleDynamically);
 	env->error_handler = error_handler;
 	if (inspector) {
 		env->EnableInspectorAgent();

--- a/src/module/isolate_handle.h
+++ b/src/module/isolate_handle.h
@@ -42,6 +42,8 @@ class IsolateHandle : public TransferableHandle {
 		auto GetReferenceCount() -> v8::Local<v8::Value>;
 		auto IsDisposedGetter() -> v8::Local<v8::Value>;
 		static auto CreateSnapshot(ArrayRange script_handles, v8::MaybeLocal<v8::String> warmup_handle) -> v8::Local<v8::Value>;
+
+		auto SetImportModuleDynamicCallback( v8::Local<v8::Function> ) -> v8::Local<v8::Value>;
 };
 
 } // namespace ivm

--- a/src/module/module_handle.cc
+++ b/src/module/module_handle.cc
@@ -103,58 +103,249 @@ auto ModuleHandle::Release() -> Local<Value> {
 }
 
 
+static void ImportResolved( const FunctionCallbackInfo<Value> &info );
+static void ImportRejected( const FunctionCallbackInfo<Value> &info );
+
+
+struct pu8pair {
+	v8::String::Utf8Value *key;
+	v8::String::Utf8Value *value;
+};
+
+struct pendingImport {
+	v8::Persistent<v8::Promise::Resolver> resolver;
+	std::shared_ptr<IsolateHolder> holder;
+	pendingImport(
+	     v8::Isolate *target_isolate
+		, v8::Persistent<v8::Promise::Resolver> &resolver
+	             , std::shared_ptr<IsolateHolder> holder )
+	    : resolver{target_isolate, resolver }
+	    , holder( holder ) {
+//		this->resolver.Reset( Isolate::GetCurrent(), resolver );
+	 }
+};
+
+v8::Local<v8::Object> GetInternalClass( Isolate *isolate ) {
+	// Prepare constructor template
+
+	v8::MaybeLocal<v8::FunctionTemplate> classTemplate
+	     = v8::FunctionTemplate::New( isolate );
+	v8::Local<v8::FunctionTemplate> classTemplate2
+	     = classTemplate.ToLocalChecked();
+	classTemplate2->SetClassName(
+	     String::NewFromUtf8Literal( isolate, "ivm::InternalTransport" ) );
+	classTemplate2->InstanceTemplate()->SetInternalFieldCount(
+	     1 ); // 1 required for arbitrary C++ pointer
+
+	Local<Function> fn
+	     = classTemplate2->GetFunction( isolate->GetCurrentContext() )
+	          .ToLocalChecked();
+	return fn->NewInstance( isolate->GetCurrentContext(), 0, nullptr ).ToLocalChecked();
+}
+
 class ImportModuleDynamicallyTask : public Runnable {
+
  public:
-	ImportModuleDynamicallyTask( Local<Promise::Resolver> resolver
+	ImportModuleDynamicallyTask( std::shared_ptr<IsolateHolder> holder
+	                           , std::shared_ptr<IsolateHolder> importing_holder
+	                           , Local<Promise::Resolver> resolver
 	                           , Local<Data> host_defined_options
-	                           , Local<Value> resource_name
-	                           , Local<String> specifier
-	                           , Local<FixedArray> import_attributes )
-	    : resolver{ Isolate::GetCurrent(), resolver }
+	                           , String::Utf8Value* resource_name
+	                           , String::Utf8Value * specifier
+	                           , int pairs
+	                           , pu8pair * import_attributes )
+	    : holder( holder )
+	    , importing_holder( importing_holder )
+	    , resolver{ resolver->GetIsolate(), resolver }
 	    , host_defined_options{ Isolate::GetCurrent(), host_defined_options }
-	    , resource_name{ Isolate::GetCurrent(), resource_name }
-	    , specifier{ Isolate::GetCurrent(), specifier }
-	    , import_attributes{ Isolate::GetCurrent(), import_attributes } {}
+	    , resource_name( resource_name )
+	    , specifier(specifier )
+	    , pairs( pairs )
+	    , import_attributes(  import_attributes ) {}
 	void Run() final {
 		Isolate *isolate = Isolate::GetCurrent();
 		printf( "Got callback import?\n" );
 		fflush( stdout );
+		/*
 		Locker locker( isolate );
 		if( !locker.IsLocked( isolate ) ) {
-			printf( "Have to wait to lock? Can we ever lock?\n" );
-			fflush( stdout );
+		   printf( "Have to wait to lock? Can we ever lock?\n" );
+		   fflush( stdout );
 		}
+		*/
 
 		HandleScope handle_scope( isolate );
-		Context::Scope context_scope{
-		     IsolateEnvironment::GetCurrent().DefaultContext() };
+		Local<Context> context  = isolate->GetCurrentContext();
+		// Context::Scope context_scope{
+		//		     IsolateEnvironment::GetCurrent().DefaultContext() };
 		IsolateEnvironment &env = IsolateEnvironment::GetCurrent();
-		shared_ptr<IsolateHolder> holder   = env.GetCurrentHolder();
+		// shared_ptr<IsolateHolder> holder   = env.GetCurrentHolder();
 		v8::Local<v8::Object> opts
-		     = host_defined_options.Get( isolate ).As<Object>( );
-		v8::Local<v8::Object> attribs
-		     = import_attributes.Get( isolate ).As<Object>();
-		Local<Value> args[ 5 ]
-		     = { resolver.Get( isolate ), opts
-		       , resource_name.Get( isolate ), specifier.Get( isolate )
-		       , attribs };
+		     = host_defined_options.Get( isolate ).As<Object>();
+
+		v8::Local<v8::Object> attribs = Object::New( isolate );
+		for( int i = 0; i < pairs; i++ ) {
+			attribs->Set( context, v8_string( ( **import_attributes[ i ].key ) )
+			            , v8_string( ( **import_attributes[ i ].value ) ) );
+		}
+		Local<Value> args[ 3 ]
+		     = { v8_string( **specifier ), v8_string( **resource_name ), attribs };
+
 		Local<Function> cb = holder->import_dynamic_callback.Get( isolate );
-		Local<Context> ctx = context.Get( isolate );
-		if( !cb.IsEmpty() )
-			cb->Call( isolate->GetCurrentContext(), Null(isolate), 5, args );
+		Local<Context> ctx = this->context.Get( isolate );
+		if( !cb.IsEmpty() ) {
+			Local<Value> promise_result = cb
+			     ->Call( isolate->GetCurrentContext(), Null( isolate ), 3, args )
+			     .ToLocalChecked();
+			Local<Promise> pr         = promise_result.As<Promise>();
+			if( !pr.IsEmpty() ) {
+				Local<Object> importExtra = GetInternalClass( isolate );
+				pendingImport *pending_import
+				     = new pendingImport( *holder->GetIsolate(), resolver, holder );
+				// printf( "Resolver isolate still? %p\n", resolverGetIsolate() );
+				importExtra->SetAlignedPointerInInternalField( 0, pending_import );
+
+				Local<Function> ft
+				     = Function::New( context, ImportResolved, importExtra )
+				          .ToLocalChecked();
+				Local<Function> fc
+				     = Function::New( context, ImportRejected, importExtra )
+				          .ToLocalChecked();
+				MaybeLocal<Promise> result = pr->Then( context, ft, fc );
+			}
+		}
 		// this->Run2( isolate, isolate->GetCurrentContext() );
 
 		isolate->PerformMicrotaskCheckpoint();
 	}
 
- private:
+ public:
 	Persistent<Context> context;
-	Persistent<Promise::Resolver> resolver;
+	v8::Persistent<v8::Promise::Resolver> resolver;
 	Persistent<Data> host_defined_options;
-	Persistent<Value> resource_name;
-	Persistent<String> specifier;
-	Persistent<FixedArray> import_attributes;
+	String::Utf8Value *resource_name;
+	String::Utf8Value* specifier;
+	int pairs;
+	pu8pair *import_attributes;
+	shared_ptr<IsolateHolder> holder;
+	shared_ptr<IsolateHolder> importing_holder;
 };
+
+
+
+struct ImportModuleDynamicallyResolveTask : public Runnable {
+	Persistent<Value> module;
+	Isolate *module_isolate;
+	//class ImportModuleDynamicallyTask *from; 
+	Persistent<Promise::Resolver> promise;
+	bool success;
+	ImportModuleDynamicallyResolveTask( Isolate *module_isolate
+	                                  , Persistent<Promise::Resolver> & promise
+	                                  , Local<Value> module )
+	    : module_isolate( module_isolate )
+	    , promise{ Isolate::GetCurrent(), promise }
+	    , module{ Isolate::GetCurrent() , module } {}
+	void Run() final {
+		// this is running in the VM isolate thread.
+		// and the module we know is in the host isolate?
+		Isolate *ivm_isolate = *Executor::GetCurrentEnvironment();
+		Isolate *isolate = Isolate::GetCurrent();
+		HandleScope handle_scope( isolate );
+		Local<Context> context = Executor::GetCurrentEnvironment()->DefaultContext();
+		Context::Scope ct( context );
+		printf( "Module isn't in this isolate... %p %p", module_isolate
+		      , isolate );
+
+		Local<Object> module = this->module.Get( module_isolate ).As<Object>();
+		Local<Context> ct2 = module->GetCreationContext().ToLocalChecked();
+		Local<Value> name           = module->GetConstructorName();
+		// printf( "Resolving Final Promise here----------------- %s\n", *String::Utf8Value( module_isolate, name ) );
+		 Local<TransferableHandle> dr = module.As<TransferableHandle>();
+		 std::unique_ptr<Transferable> drval = dr->TransferOut();
+
+		Local<Promise::Resolver> pr = promise.Get( isolate );
+
+		pr->Resolve( isolate->GetCurrentContext(), drval->TransferIn() );
+
+		printf( "dispatch resolved promises??\n" );
+		isolate->PerformMicrotaskCheckpoint();
+		printf( "Finish run...\n" );
+	}
+};
+
+struct ImportModuleDynamicallyRejectTask : public Runnable {
+	class ImportModuleDynamicallyTask *from;
+	bool success;
+	ImportModuleDynamicallyRejectTask(
+	     class ImportModuleDynamicallyTask *from ): from(from) {}
+	void Run() final {
+		
+		Isolate *isolate = Isolate::GetCurrent();
+		HandleScope handle_scope( isolate );
+		from->resolver.Get( isolate )->Reject(
+		     from->context.Get( isolate ), Undefined( Isolate::GetCurrent() ) );
+	}
+};
+
+static void ImportResolved( const
+                               FunctionCallbackInfo<Value> &info ) {
+	// this is a callback triggered in the host isolate.
+	// it comes from the Host code linker resolution.
+	// info should be an ivm module... which is portable?
+	Isolate *isolate                  = Isolate::GetCurrent();
+	// this needs to be posted to the VM to resolve the import()
+	// in the vm isolate.
+	Local<Object> importExtra = info.Data().As<Object>();
+	Local<Promise::Resolver> resolver = importExtra
+	     ->Get( info.GetIsolate()->GetCurrentContext(), v8_string( "resolver" ) )
+	     .ToLocalChecked()
+	     .As<Promise::Resolver>();
+	//Local<Object>  = info[0].As<Object>();
+
+	// this is back in the UV context/thread
+	pendingImport *pending_import
+	     = (pendingImport *)importExtra->GetAlignedPointerFromInternalField( 0 );
+	shared_ptr<IsolateHolder> importing_holder = pending_import->holder;
+
+	     //= (IsolateHolder *)importExtra->GetAlignedPointerFromInternalField( 0 );
+
+	//importing_holder = o.Get( info.GetIsolate() );
+	Local<Object> module = info[ 0 ].As<Object>();
+	Local<Module> m2                           = Local<Module>::Cast( module );
+	//m2->
+	String::Utf8Value name( info.GetIsolate(), module->GetConstructorName() );
+
+	Local<ReferenceHandle> ns = module
+	     ->Get( info.GetIsolate()->GetCurrentContext()
+	          , v8_string( "namespace" ) )
+	     .ToLocalChecked()
+	     .As<ReferenceHandle>();
+	String::Utf8Value nsName( ns.As<Object>()->GetIsolate()
+	                        , ns.As<Object>()->GetConstructorName() );
+	Local<Value> dri = ns->DerefInto( MaybeLocal<Object>() );
+	//Isolate *chk = ns->GetIsolate();
+	//Local<Context> chkctx = ns->GetCreationContext().ToLocalChecked();
+	//Local<Array> names = module->GetPropertyNames( info.GetIsolate()->GetCurrentContext() ).ToLocalChecked();
+
+
+
+	importing_holder->ScheduleTask(
+	     std::make_unique<struct ImportModuleDynamicallyResolveTask>(
+	          info.GetIsolate(), pending_import->resolver, dri )
+			     , false, true, false );
+	
+}
+
+void ImportRejected( const FunctionCallbackInfo<Value> &info ) {
+	// this is a callback triggered in the host isolate.
+
+	/*
+			importing_holder->ScheduleTask(
+			     std::make_unique<ImportModuleDynamicallyRejectTask>(this)
+			     , false, true, false );
+	*/
+}
+
 
 v8::MaybeLocal<v8::Promise>
 ModuleHandle::ImportModuleDynamically( v8::Local<v8::Context> context
@@ -162,33 +353,67 @@ ModuleHandle::ImportModuleDynamically( v8::Local<v8::Context> context
                                      , v8::Local<v8::Value> resource_name
                                      , v8::Local<v8::String> specifier
                                      , v8::Local<v8::FixedArray> import_attributes ) {
-	// this is called from the v8::Module::Instantiate() method
+	Isolate* isolate = Isolate::GetCurrent();
+	String::Utf8Value *r_name = new String::Utf8Value ( isolate, resource_name );
+	String::Utf8Value *spec   = new String::Utf8Value( isolate, specifier );
+
+#if 0
+	// never had host_defined_options with content; but the one I did get
+	// was a FixedArray with 0 length.
+	// v8::Local<v8::Value> hdo   = Local<Value>::Cast( host_defined_options );
+	if( host_defined_options->IsValue() ) {
+		//printf( "Host Defined Options is an Value\n" );
+	} else if( host_defined_options->IsModule() ) {
+		//printf( "Host Defined Options is a IsModule\n" );
+	} else if( host_defined_options->IsContext() ) {
+		//printf( "Host Defined Options is a IsContext\n" );
+	} else if( host_defined_options->IsPrivate() ) {
+		//printf( "Host Defined Options is a IsPrivate\n" );
+	} else if( host_defined_options->IsFixedArray() ) {
+		/*
+		Local<FixedArray> fa = Local<FixedArray>::Cast( host_defined_options );
+		for( int i = 0; i < fa->Length(); i++ ) {
+			v8::Local<v8::Data> v   = fa->Get( context, i );
+			v8::Local<v8::Value> v2 = Local<Value>::Cast( v );
+			// printf( "host_defined_options[%d]: %s\n", i
+			//			      , *String::Utf8Value( isolate, v2 ) );
+		}
+		*/
+		// printf( "Host Defined Options is a IsFixedArray\n" );
+	} else if( host_defined_options->IsFunctionTemplate() ) {
+		// printf( "Host Defined Options is a IsFunctionTemplate\n" );
+	} else {
+		//printf( "Host Defined Options is a ???\n"  );
+	}
+#endif
+
+	pu8pair *attribs = new pu8pair[ import_attributes->Length() ];
+	for( int i = 0; i < import_attributes->Length(); i++ ) {
+		v8::Local<v8::Data> v = import_attributes->Get( context, i );
+		v8::Local<v8::Value> v2 = Local<Value>::Cast( v );
+		if( i & 1 )
+			attribs[ i/2 ].value = new String::Utf8Value( isolate, v2 );
+		else
+			attribs[ i/2 ].key   = new String::Utf8Value( isolate, v2 );
+	}
+	
+	// this is called from the import() method
 	// which will be running in the ivm instance; and context
 	// so this has to be uv_scheduled to the main thread
-	Local<Promise::Resolver> resolver
-	     = Unmaybe( Promise::Resolver::New( context ) );
-	Local<Promise> promise = resolver->GetPromise();
-
-	if( !IsolateEnvironment::GetCurrent().GetCurrentHolder()->import_dynamic_callback.IsEmpty() ) {
-		printf( "how to get a proper runner to post my task to UV loop?\n" );
-		Executor::GetCurrentEnvironment()->GetTaskRunner()->PostTask(
+	Local<Promise::Resolver> resolver = Unmaybe( Promise::Resolver::New( context ) );
+	//IsolateEnvironment& defenv = Executor::GetDefaultEnvironment();
+	printf( "Resolver isolate %p %p\n", isolate, resolver->GetIsolate() );
+	shared_ptr<IsolateHolder> holder = IsolateEnvironment::GetCurrent().GetCurrentHolder();
+	if( !holder->import_dynamic_callback.IsEmpty() ) {
+		holder->import_dynamic_callback_host_isolate->ScheduleTask(
 		     std::make_unique<ImportModuleDynamicallyTask>(
-		          resolver, host_defined_options, resource_name, specifier
-		          , import_attributes ) );
-		/*
-		IsolateEnvironment::GetCurrent().GetTaskRunner()->PostTask(
-			 std::make_unique<ImportModuleDynamicallyTask>(
-			 resolver, host_defined_options, resource_name, specifier
-			 , import_attributes ) );
-			 */
+		          holder, holder->import_dynamic_callback_host_isolate, resolver
+		          , host_defined_options, r_name, spec, import_attributes->Length()/2, attribs )
+		     , false, true, false );
 	}else
 		resolver->Reject( context, v8_string( "dynamic import callback not registered" ) );
-	/*
-	IsolateEnvironment::GetCurrentHolder().get()->ScheduleTask(
-	     std::make_unique<ImportModuleDynamicallyTask>(promise, host_defined_options, resource_name, specifier, import_attributes ), false, true, false );
-	*/
 
-	return MaybeLocal<Promise>(promise);
+	return MaybeLocal<Promise>( resolver->GetPromise() );
 }
 
 

--- a/src/module/module_handle.cc
+++ b/src/module/module_handle.cc
@@ -102,6 +102,96 @@ auto ModuleHandle::Release() -> Local<Value> {
 	return Undefined(Isolate::GetCurrent());
 }
 
+
+class ImportModuleDynamicallyTask : public Runnable {
+ public:
+	ImportModuleDynamicallyTask( Local<Promise::Resolver> resolver
+	                           , Local<Data> host_defined_options
+	                           , Local<Value> resource_name
+	                           , Local<String> specifier
+	                           , Local<FixedArray> import_attributes )
+	    : resolver{ Isolate::GetCurrent(), resolver }
+	    , host_defined_options{ Isolate::GetCurrent(), host_defined_options }
+	    , resource_name{ Isolate::GetCurrent(), resource_name }
+	    , specifier{ Isolate::GetCurrent(), specifier }
+	    , import_attributes{ Isolate::GetCurrent(), import_attributes } {}
+	void Run() final {
+		Isolate *isolate = Isolate::GetCurrent();
+		printf( "Got callback import?\n" );
+		fflush( stdout );
+		Locker locker( isolate );
+		if( !locker.IsLocked( isolate ) ) {
+			printf( "Have to wait to lock? Can we ever lock?\n" );
+			fflush( stdout );
+		}
+
+		HandleScope handle_scope( isolate );
+		Context::Scope context_scope{
+		     IsolateEnvironment::GetCurrent().DefaultContext() };
+		IsolateEnvironment &env = IsolateEnvironment::GetCurrent();
+		shared_ptr<IsolateHolder> holder   = env.GetCurrentHolder();
+		v8::Local<v8::Object> opts
+		     = host_defined_options.Get( isolate ).As<Object>( );
+		v8::Local<v8::Object> attribs
+		     = import_attributes.Get( isolate ).As<Object>();
+		Local<Value> args[ 5 ]
+		     = { resolver.Get( isolate ), opts
+		       , resource_name.Get( isolate ), specifier.Get( isolate )
+		       , attribs };
+		Local<Function> cb = holder->import_dynamic_callback.Get( isolate );
+		Local<Context> ctx = context.Get( isolate );
+		if( !cb.IsEmpty() )
+			cb->Call( isolate->GetCurrentContext(), Null(isolate), 5, args );
+		// this->Run2( isolate, isolate->GetCurrentContext() );
+
+		isolate->PerformMicrotaskCheckpoint();
+	}
+
+ private:
+	Persistent<Context> context;
+	Persistent<Promise::Resolver> resolver;
+	Persistent<Data> host_defined_options;
+	Persistent<Value> resource_name;
+	Persistent<String> specifier;
+	Persistent<FixedArray> import_attributes;
+};
+
+v8::MaybeLocal<v8::Promise>
+ModuleHandle::ImportModuleDynamically( v8::Local<v8::Context> context
+                                     , v8::Local<v8::Data> host_defined_options
+                                     , v8::Local<v8::Value> resource_name
+                                     , v8::Local<v8::String> specifier
+                                     , v8::Local<v8::FixedArray> import_attributes ) {
+	// this is called from the v8::Module::Instantiate() method
+	// which will be running in the ivm instance; and context
+	// so this has to be uv_scheduled to the main thread
+	Local<Promise::Resolver> resolver
+	     = Unmaybe( Promise::Resolver::New( context ) );
+	Local<Promise> promise = resolver->GetPromise();
+
+	if( !IsolateEnvironment::GetCurrent().GetCurrentHolder()->import_dynamic_callback.IsEmpty() ) {
+		printf( "how to get a proper runner to post my task to UV loop?\n" );
+		Executor::GetCurrentEnvironment()->GetTaskRunner()->PostTask(
+		     std::make_unique<ImportModuleDynamicallyTask>(
+		          resolver, host_defined_options, resource_name, specifier
+		          , import_attributes ) );
+		/*
+		IsolateEnvironment::GetCurrent().GetTaskRunner()->PostTask(
+			 std::make_unique<ImportModuleDynamicallyTask>(
+			 resolver, host_defined_options, resource_name, specifier
+			 , import_attributes ) );
+			 */
+	}else
+		resolver->Reject( context, v8_string( "dynamic import callback not registered" ) );
+	/*
+	IsolateEnvironment::GetCurrentHolder().get()->ScheduleTask(
+	     std::make_unique<ImportModuleDynamicallyTask>(promise, host_defined_options, resource_name, specifier, import_attributes ), false, true, false );
+	*/
+
+	return MaybeLocal<Promise>(promise);
+}
+
+
 void ModuleHandle::InitializeImportMeta(Local<Context> context, Local<Module> module, Local<Object> meta) {
 	ModuleInfo* found = LookupModuleInfo(module);
 	if (found != nullptr) {

--- a/src/module/module_handle.h
+++ b/src/module/module_handle.h
@@ -63,6 +63,12 @@ class ModuleHandle : public TransferableHandle {
 		auto GetNamespace() -> v8::Local<v8::Value>;
 
 		static void InitializeImportMeta(v8::Local<v8::Context> context, v8::Local<v8::Module> module, v8::Local<v8::Object> meta);
+
+		static v8::MaybeLocal<v8::Promise> ModuleHandle::ImportModuleDynamically(v8::Local<v8::Context> context, v8::Local<v8::Data> host_defined_options
+				, v8::Local<v8::Value> resource_name
+				, v8::Local<v8::String> specifier
+				, v8::Local<v8::FixedArray> import_attributes
+				 );
 };
 
 } // namespace ivm


### PR DESCRIPTION
Implement dynamic import callback.

1) creating a new isolate registers the native info callback - this happens in the VM isolate/context.
2) JS code in host context registers a callback.
3) JS code in VM calls dynamic `import()`
  a) dispatch import task to Host thread callback with current module name, import specifier, and import `with` options.
  b) return a promise which will be resolved later; hold on to the promise.
4) Host isolate callback runs, can use the referring module name to get the module specified - the name is the {filename:} option passed to `compileModule()`.  At this point the typical import path can be used to load the module from the specifier.
  a) whitelisting might also consider the module loading the imported script.
5) import process completes and results with a module, triggering `Then()` handler on the `Promise::Resolver`; which schedules the resolve back in the VM thread to resolve to the `import()` function.

| Host Action| VM Action| 
|---|---|
| Create Isolate; register v8 callback(C++) | |
| specify JS callback for Isolate |  |
| Load code into IVM |  |
|  | import() triggers registers v8 callback(C++) |
|  | v8 callback sends work to host(JS), results with promise |
| Import JS callback is called (JS) |  |
| specifier resolved, compiled, instantiated, and executed (JS) |  |
| resolve with Module (JS) |  |
| Then() dispatches resolved promise result to VM (C++) |   |
|   | VM Task gets resolved module(C++) |
|   | VM resolves import() promise with module.namespace(C++) |

